### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -61,6 +61,7 @@
   <description lang="zh">你可以使用此Web界面控制XBMC音/视频：播放/暂停/停止/跳过，显示艺人/专辑/电影/剧集并播放或加入播放列表。用于台式机或便携机上支持JavaScript的浏览器，如FireFox。[CR][CR]最低要求：XBMC Frodo[CR]测试浏览器：[CR] - FireFox[CR] - Chromium[CR] - Internet Explorer 9[CR]不支持：Internet Explorer 6[CR][CR]提示：当你在浏览器打开新安装或升级的Web界面前，可能需要先清除浏览器缓存。强烈建议使用支持web sockets的浏览器，这不包括IE 9。</description>
   <language></language>
   <platform>all</platform>
+  <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
   <forum>http://forum.kodi.tv/showthread.php?tid=112956</forum>
   <source>https://github.com/mizaki/awxi</source>
   </extension>


### PR DESCRIPTION
Needed to automatically fill field on http://kodi.wiki and http://addons.kodi.tv/ sites.
