### PR TITLE
Add better URL parameter handler for Youtube

### DIFF
--- a/js/ui.views.js
+++ b/js/ui.views.js
@@ -3983,7 +3983,8 @@ var uiviews = {};
           $addonsList.find('form#youtubeplay').on('submit', function() {
             var messageHandle = mkf.messageLog.show(mkf.lang.get('Playing...', 'Popup message with addition'));
             //Grab you tube id and make playable uri.
-            var ytid = $('input#ytplay').val().substr($('input#ytplay').val().lastIndexOf("=") + 1);
+            var ytplay = $('input#ytplay').val();
+            var ytid = uiviews.UrlParam('v', ytplay);
             var fullURL = 'plugin://plugin.video.youtube/?action=play_video&videoid=' + ytid;
             
             xbmc.playerOpen({
@@ -5067,7 +5068,21 @@ var uiviews = {};
       mkf.dialog.setContent(dialogHandle, dialogContent);
 
       return false;
+    },
+
+    /*----------------------------------------------------*/
+    /*               Handle URL parameters 
+    /* (http://www.sitepoint.com/url-parameters-jquery/)  */
+    /*----------------------------------------------------*/                                                                  
+    UrlParam: function(name, url) {
+      var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(url);
+      if (results == null) {
+        return null;
+      }
+      else {
+        return results[1] || 0;
+      }
     }
-    
+
   }); // END ui.views
 })(jQuery);


### PR DESCRIPTION
The interface was assuming that the  last parameter of the
Youtube URL was the video id, sometimes this is not true. For
example when you paste a URL from a youtube list, the URL has
extra arguments (like list and index), in this scenario taking
the last argument does not work.

With this patch you can paste any valid youtube URL and it will be
played.
